### PR TITLE
Correct the calculation for the bestOffset so the prefix will be replaced during completion

### DIFF
--- a/src/main/java/org/microshed/lsp4ij/operations/completion/LSPCompletionProposal.java
+++ b/src/main/java/org/microshed/lsp4ij/operations/completion/LSPCompletionProposal.java
@@ -161,9 +161,9 @@ public class LSPCompletionProposal extends LookupElement {
         }
         String insertText = getInsertText();
         try {
-            String subDoc = document.getText(new TextRange(
-                    Math.max(0, completionOffset - insertText.length()),
-                    Math.min(insertText.length(), completionOffset)));
+            int startOffset = Math.max(0, completionOffset - insertText.length());
+            int endOffset = Math.min(startOffset + insertText.length(), completionOffset);
+            String subDoc = document.getText(new TextRange(startOffset, endOffset));
             for (int i = 0; i < insertText.length() && i < completionOffset; i++) {
                 String tentativeCommonString = subDoc.substring(i);
                 if (insertText.startsWith(tentativeCommonString)) {


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/liberty-tools-intellij/issues/622

This code is actually restored from a prior version of this file. The difference is in the end offset of the sub document being examined.