### PR TITLE
Add required dependencies on flexmark. Update GSON dependency. Reduce jar size.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,11 @@ dependencies {
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.21.0'
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.21.0'
     //required by lsp4j as the version from IJ is incompatible
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.vladsch.flexmark:flexmark:0.64.8'
+    implementation 'com.vladsch.flexmark:flexmark-ext-tables:0.64.8'
+    implementation 'com.vladsch.flexmark:flexmark-ext-autolink:0.64.8'
+    implementation 'com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:0.64.8'
     //Add junit dependency back when tests are added
 }
 
@@ -75,18 +79,6 @@ configurations.implementation.setCanBeResolved(true)
 jar {
     manifest {
         attributes "Main-Class": "MainClass"
-    }
-
-    from {
-        configurations.implementation.collect { it.isDirectory() ? it : zipTree(it) }
-    } {
-        exclude "META-INF/*.SF"
-        exclude "META-INF/*.DSA"
-        exclude "META-INF/*.RSA"
-        duplicatesStrategy 'include' // error copying duplicate about.html
-    }
-    from { sourceSets.main.allSource } {
-        duplicatesStrategy 'exclude' // error copying .properties when adding source to jar
     }
     extension 'jar'
 }


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/721.

- Align flexmark and GSON dependencies with current Red Hat LSP4iJ.
- Remove dependencies from the jar. These are automatically being pulled in by consumers that read the generated Maven `pom.xml` so this is eliminating duplicate copies of these binaries and reducing the size of the archive.