### PR TITLE
fix: Find usages on a Java file can generate many IDE internal errors.

### DIFF
--- a/src/main/java/org/microshed/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/org/microshed/lsp4ij/usages/LSPUsageSearcher.java
@@ -12,6 +12,7 @@ package org.microshed.lsp4ij.usages;
 
 import com.intellij.find.findUsages.CustomUsageSearcher;
 import com.intellij.find.findUsages.FindUsagesOptions;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.psi.PsiElement;
@@ -62,7 +63,7 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
             }
         }
 
-        // Get position where the "Find USages" has been triggered
+        // Get position where the "Find Usages" has been triggered
         Position position = getPosition(element);
         // Collect textDocument/definition, textDocument/references, etc
         LSPUsageSupport usageSupport = new LSPUsageSupport(element.getContainingFile());
@@ -85,7 +86,14 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
         }
     }
 
-    private Position getPosition(PsiElement element) {
+    private static Position getPosition(PsiElement element) {
+        if (ApplicationManager.getApplication().isReadAccessAllowed()) {
+            return doGetPosition(element);
+        }
+        return ReadAction.compute(() -> doGetPosition(element));
+    }
+
+    private static Position doGetPosition(PsiElement element) {
         Document document = LSPIJUtils.getDocument(element.getContainingFile().getVirtualFile());
         return LSPIJUtils.toPosition(Math.min(element.getTextRange().getStartOffset() + 1, element.getTextRange().getEndOffset()), document);
     }


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/735. This is identical to the PR https://github.com/redhat-developer/lsp4ij/pull/274 that was applied to the Red Hat LSP4iJ project.